### PR TITLE
update bid/imp to hold contentType

### DIFF
--- a/bid.go
+++ b/bid.go
@@ -42,6 +42,7 @@ type Bid struct {
 	WRatio         int            `json:"wratio,omitempty"`         // Relative width of the creative when expressing size as a ratio.
 	HRatio         int            `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
 	Exp            int            `json:"exp,omitempty"`            // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
+	ContentType    string         `json:"-"`                        // content of the bid
 	Ext            Extension      `json:"ext,omitempty"`
 }
 

--- a/impression.go
+++ b/impression.go
@@ -32,6 +32,7 @@ type Impression struct {
 	Secure            NumberOrString `json:"secure,omitempty"`            // Flag to indicate whether the impression requires secure HTTPS URL creative assets and markup.
 	Exp               int            `json:"exp,omitempty"`               // Advisory as to the number of seconds that may elapse between the auction and the actual impression.
 	IFrameBuster      []string       `json:"iframebuster,omitempty"`      // Array of names for supportediframe busters.
+	ContentType       string         `json:"-"`                           // Used to attribute bid to a content - not sent in request
 	Ext               Extension      `json:"ext,omitempty"`
 }
 


### PR DESCRIPTION
* adds contentType to bid and impression 
* allows us to send multiple impressions for a placement, one per type and map that back to bid
* Is only internal - not sent in JSON