### PR TITLE
Add MediaType To Bid and Impression

### DIFF
--- a/bid.go
+++ b/bid.go
@@ -43,6 +43,7 @@ type Bid struct {
 	HRatio         int            `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
 	Exp            int            `json:"exp,omitempty"`            // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
 	ContentType    string         `json:"-"`                        // content of the bid
+	MediaType      string         `json:"-"`                        // media of the impression e.g. video/display
 	Ext            Extension      `json:"ext,omitempty"`
 }
 

--- a/impression.go
+++ b/impression.go
@@ -33,6 +33,7 @@ type Impression struct {
 	Exp               int            `json:"exp,omitempty"`               // Advisory as to the number of seconds that may elapse between the auction and the actual impression.
 	IFrameBuster      []string       `json:"iframebuster,omitempty"`      // Array of names for supportediframe busters.
 	ContentType       string         `json:"-"`                           // Used to attribute bid to a content - not sent in request
+	MediaType         string         `json:"-"`                           // media of the impression e.g. video/display
 	Ext               Extension      `json:"ext,omitempty"`
 }
 

--- a/openrtb.go
+++ b/openrtb.go
@@ -279,8 +279,8 @@ type Segment struct {
 // coppa flag signals whether or not the request falls under the United States Federal Trade Commission's
 // regulations for the United States Children's Online Privacy Protection Act ("COPPA").
 type Regulations struct {
-	Coppa int       `json:"coppa,omitempty"` // Flag indicating if this request is subject to the COPPA regulations established by the USA FTC, where 0 = no, 1 = yes.
-	Ext   Extension `json:"ext,omitempty"`
+	Coppa int          `json:"coppa,omitempty"` // Flag indicating if this request is subject to the COPPA regulations established by the USA FTC, where 0 = no, 1 = yes.
+	Ext   RegExtension `json:"ext,omitempty"`
 }
 
 // This object represents an allowed size (i.e., height and width combination) for a banner impression.
@@ -289,4 +289,9 @@ type Format struct {
 	W   int       `json:"w,omitempty"` // Width in device independent pixels (DIPS).
 	H   int       `json:"h,omitempty"` //Height in device independent pixels (DIPS).
 	Ext Extension `json:"ext,omitempty"`
+}
+
+// RegExtension Extension object for Regulations
+type RegExtension struct {
+	GDPR int `json:"gdpr,omitempty"`
 }


### PR DESCRIPTION
* required for request consolidation
* add media type to our bid/impression objects but do not marshal into JSON