### PR TITLE
[APIN-1583] Add consent field in openRTB user extension

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -242,16 +242,16 @@ type Geo struct {
 // privacy policies. However, this user ID must be stable long enough to serve reasonably as the basis for
 // frequency capping and retargeting.
 type User struct {
-	ID         string    `json:"id,omitempty"`         // Unique consumer ID of this user on the exchange
-	BuyerID    string    `json:"buyerid,omitempty"`    // Buyer-specific ID for the user as mapped by the exchange for the buyer. At least one of buyeruid/buyerid or id is recommended. Valid for OpenRTB 2.3.
-	BuyerUID   string    `json:"buyeruid,omitempty"`   // Buyer-specific ID for the user as mapped by the exchange for the buyer. Same as BuyerID but valid for OpenRTB 2.2.
-	YOB        int       `json:"yob,omitempty"`        // Year of birth as a 4-digit integer.
-	Gender     string    `json:"gender,omitempty"`     // Gender ("M": male, "F" female, "O" Other)
-	Keywords   string    `json:"keywords,omitempty"`   // Comma separated list of keywords, interests, or intent
-	CustomData string    `json:"customdata,omitempty"` // Optional feature to pass bidder data that was set in the exchange's cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include "escaped" quotation marks.
-	Geo        *Geo      `json:"geo,omitempty"`
-	Data       []Data    `json:"data,omitempty"`
-	Ext        Extension `json:"ext,omitempty"`
+	ID         string        `json:"id,omitempty"`         // Unique consumer ID of this user on the exchange
+	BuyerID    string        `json:"buyerid,omitempty"`    // Buyer-specific ID for the user as mapped by the exchange for the buyer. At least one of buyeruid/buyerid or id is recommended. Valid for OpenRTB 2.3.
+	BuyerUID   string        `json:"buyeruid,omitempty"`   // Buyer-specific ID for the user as mapped by the exchange for the buyer. Same as BuyerID but valid for OpenRTB 2.2.
+	YOB        int           `json:"yob,omitempty"`        // Year of birth as a 4-digit integer.
+	Gender     string        `json:"gender,omitempty"`     // Gender ("M": male, "F" female, "O" Other)
+	Keywords   string        `json:"keywords,omitempty"`   // Comma separated list of keywords, interests, or intent
+	CustomData string        `json:"customdata,omitempty"` // Optional feature to pass bidder data that was set in the exchange's cookie. The string must be in base85 cookie safe characters and be in any format. Proper JSON encoding must be used to include "escaped" quotation marks.
+	Geo        *Geo          `json:"geo,omitempty"`
+	Data       []Data        `json:"data,omitempty"`
+	Ext        UserExtension `json:"ext,omitempty"`
 }
 
 // The data and segment objects together allow additional data about the user to be specified. This data
@@ -294,4 +294,9 @@ type Format struct {
 // RegExtension Extension object for Regulations
 type RegExtension struct {
 	GDPR int `json:"gdpr,omitempty"`
+}
+
+// UserExtension Extension object for User
+type UserExtension struct {
+	Consent int `json:"consent,omitempty"`
 }


### PR DESCRIPTION
JIRA: https://jira.hq.unity3d.com/browse/APIN-1583
For GDPR consent workflow, based on user's consent decision, we will add user.ext.consent = 1. Currently User extension has no consent field. That's why I added this field.