### PR TITLE
[APIN-1739]Remove omitempty from connectiontype

### DIFF
--- a/device.go
+++ b/device.go
@@ -26,7 +26,7 @@ type Device struct {
 	Language   string    `json:"language,omitempty"`       // Browser language
 	Carrier    string    `json:"carrier,omitempty"`        // Carrier or ISP derived from the IP address
 	MCCMNC     string    `json:"mccmnc,omitempty"`         // Mobile carrier as the concatenated MCC-MNC code (e.g., "310-005" identifies Verizon Wireless CDMA in the USA).
-	ConnType   int       `json:"connectiontype,omitempty"` // Network connection type.
+	ConnType   int       `json:"connectiontype"` // Network connection type.
 	IFA        string    `json:"ifa,omitempty"`            // Native identifier for advertisers
 	IDSHA1     string    `json:"didsha1,omitempty"`        // SHA1 hashed device ID
 	IDMD5      string    `json:"didmd5,omitempty"`         // MD5 hashed device ID

--- a/device.go
+++ b/device.go
@@ -4,35 +4,35 @@ package openrtb
 // platform, location, and carrier. This device can refer to a mobile handset, a desktop computer,
 // set top box or other digital device.
 type Device struct {
-	UA         string    `json:"ua,omitempty"`             // User agent
-	Geo        *Geo      `json:"geo,omitempty"`            // Location of the device assumed to be the user’s current location
-	DNT        int       `json:"dnt,omitempty"`            // "1": Do not track
-	LMT        int       `json:"lmt,omitempty"`            // "1": Limit Ad Tracking
-	IP         string    `json:"ip,omitempty"`             // IPv4
-	IPv6       string    `json:"ipv6,omitempty"`           // IPv6
-	DeviceType int       `json:"devicetype,omitempty"`     // The general type of device.
-	Make       string    `json:"make,omitempty"`           // Device make
-	Model      string    `json:"model,omitempty"`          // Device model
-	OS         string    `json:"os,omitempty"`             // Device OS
-	OSVer      string    `json:"osv,omitempty"`            // Device OS version
-	HwVer      string    `json:"hwv,omitempty"`            // Hardware version of the device (e.g., "5S" for iPhone 5S).
-	H          int       `json:"h,omitempty"`              // Physical height of the screen in pixels.
-	W          int       `json:"w,omitempty"`              // Physical width of the screen in pixels.
-	PPI        int       `json:"ppi,omitempty"`            // Screen size as pixels per linear inch.
-	PxRatio    float64   `json:"pxratio,omitempty"`        // The ratio of physical pixels to device independent pixels.
-	JS         int       `json:"js,omitempty"`             // Javascript status ("0": Disabled, "1": Enabled)
-	GeoFetch   int       `json:"geofetch,omitempty"`       // Indicates if the geolocation API will be available to JavaScript code running in the banner,
-	FlashVer   string    `json:"flashver,omitempty"`       // Flash version
-	Language   string    `json:"language,omitempty"`       // Browser language
-	Carrier    string    `json:"carrier,omitempty"`        // Carrier or ISP derived from the IP address
-	MCCMNC     string    `json:"mccmnc,omitempty"`         // Mobile carrier as the concatenated MCC-MNC code (e.g., "310-005" identifies Verizon Wireless CDMA in the USA).
-	ConnType   int       `json:"connectiontype"` // Network connection type.
-	IFA        string    `json:"ifa,omitempty"`            // Native identifier for advertisers
-	IDSHA1     string    `json:"didsha1,omitempty"`        // SHA1 hashed device ID
-	IDMD5      string    `json:"didmd5,omitempty"`         // MD5 hashed device ID
-	PIDSHA1    string    `json:"dpidsha1,omitempty"`       // SHA1 hashed platform device ID
-	PIDMD5     string    `json:"dpidmd5,omitempty"`        // MD5 hashed platform device ID
-	MacSHA1    string    `json:"macsha1,omitempty"`        // SHA1 hashed device ID; IMEI when available, else MEID or ESN
-	MacMD5     string    `json:"macmd5,omitempty"`         // MD5 hashed device ID; IMEI when available, else MEID or ESN
+	UA         string    `json:"ua,omitempty"`         // User agent
+	Geo        *Geo      `json:"geo,omitempty"`        // Location of the device assumed to be the user’s current location
+	DNT        int       `json:"dnt,omitempty"`        // "1": Do not track
+	LMT        int       `json:"lmt,omitempty"`        // "1": Limit Ad Tracking
+	IP         string    `json:"ip,omitempty"`         // IPv4
+	IPv6       string    `json:"ipv6,omitempty"`       // IPv6
+	DeviceType int       `json:"devicetype,omitempty"` // The general type of device.
+	Make       string    `json:"make,omitempty"`       // Device make
+	Model      string    `json:"model,omitempty"`      // Device model
+	OS         string    `json:"os,omitempty"`         // Device OS
+	OSVer      string    `json:"osv,omitempty"`        // Device OS version
+	HwVer      string    `json:"hwv,omitempty"`        // Hardware version of the device (e.g., "5S" for iPhone 5S).
+	H          int       `json:"h,omitempty"`          // Physical height of the screen in pixels.
+	W          int       `json:"w,omitempty"`          // Physical width of the screen in pixels.
+	PPI        int       `json:"ppi,omitempty"`        // Screen size as pixels per linear inch.
+	PxRatio    float64   `json:"pxratio,omitempty"`    // The ratio of physical pixels to device independent pixels.
+	JS         int       `json:"js,omitempty"`         // Javascript status ("0": Disabled, "1": Enabled)
+	GeoFetch   int       `json:"geofetch,omitempty"`   // Indicates if the geolocation API will be available to JavaScript code running in the banner,
+	FlashVer   string    `json:"flashver,omitempty"`   // Flash version
+	Language   string    `json:"language,omitempty"`   // Browser language
+	Carrier    string    `json:"carrier,omitempty"`    // Carrier or ISP derived from the IP address
+	MCCMNC     string    `json:"mccmnc,omitempty"`     // Mobile carrier as the concatenated MCC-MNC code (e.g., "310-005" identifies Verizon Wireless CDMA in the USA).
+	ConnType   int       `json:"connectiontype"`       // Network connection type.
+	IFA        string    `json:"ifa,omitempty"`        // Native identifier for advertisers
+	IDSHA1     string    `json:"didsha1,omitempty"`    // SHA1 hashed device ID
+	IDMD5      string    `json:"didmd5,omitempty"`     // MD5 hashed device ID
+	PIDSHA1    string    `json:"dpidsha1,omitempty"`   // SHA1 hashed platform device ID
+	PIDMD5     string    `json:"dpidmd5,omitempty"`    // MD5 hashed platform device ID
+	MacSHA1    string    `json:"macsha1,omitempty"`    // SHA1 hashed device ID; IMEI when available, else MEID or ESN
+	MacMD5     string    `json:"macmd5,omitempty"`     // MD5 hashed device ID; IMEI when available, else MEID or ESN
 	Ext        Extension `json:"ext,omitempty"`
 }


### PR DESCRIPTION
### Problem
The implementation for 'connectiontype' guarantees the field should be always in the bid request.

But there are cases the field is missing. 

https://console.cloud.google.com/logs/viewer?interval=NO_LIMIT&project=unity-ads-exchg-gke-prd&authuser=0&organizationId=1050374768111&orgonly=true&minLogLevel=0&expandAll=false&timestamp=2019-06-13T07:52:47.616000000Z&customFacets=&limitCustomFacetWidth=true&scrollTimestamp=2019-06-13T10:17:35.000000000Z&advancedFilter=resource.type%3D%22container%22%0Aresource.labels.cluster_name%3D%22unity-ads-exchg-auction-gke-prd-usc1%22%0Aresource.labels.namespace_id%3D%22ads%22%0Aresource.labels.project_id%3D%22unity-ads-exchg-gke-prd%22%0Aresource.labels.zone:%22us-central1-%22%0Aresource.labels.container_name%3D(%22init-vault-secret-fetcher%22%20OR%20%22ads-brand%22)%0Aresource.labels.pod_id:%22ads-brand-%22%0AjsonPayload.message:%22Payload%22%0ANOT%20jsonPayload.message:%22user_agent%22%0ANOT%20jsonPayload.message:%22connectiontype%22%0A

### WHY
omitempty will drop the field when it is an empty value.
But for 'connectiontype' field, 0 is a valid type in openrtb spec and should be parsed to our DSPs.

### HOW
remove omitempty from connectiontype

### JIRA
https://jira.hq.unity3d.com/browse/APIN-1739