### PR TITLE
[APIN-1921] Add more constants to 5.6 API Frameworks

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -56,6 +56,8 @@ const (
 	APIFrameworkMRAID1 = 3
 	APIFrameworkORMMA  = 4
 	APIFrameworkMRAID2 = 5
+	APIFrameworkMRAID3 = 6
+	APIFrameworkOMID1  = 7
 )
 
 // 5.7 Video Linearity


### PR DESCRIPTION
Add constants to List 5.6 API Frameworks

![image](https://user-images.githubusercontent.com/22989396/63317900-675eec80-c2c9-11e9-9d20-3d7f58212dad.png)

https://s3-us-west-2.amazonaws.com/omsdk-files/docs/Open+Measurement+SDK+Onboarding_version_1.2.pdf