### PR TITLE
[APIN-1932]fix empty string decoding issue

### DIFF
--- a/numbers.go
+++ b/numbers.go
@@ -36,7 +36,7 @@ type StringOrNumber string
 
 // UnmarshalJSON implements json.Unmarshaler
 func (n *StringOrNumber) UnmarshalJSON(data []byte) error {
-	if len(data) > 2 && data[0] == '"' && data[len(data)-1] == '"' {
+	if len(data) >= 2 && data[0] == '"' && data[len(data)-1] == '"' {
 		var v string
 		if err := json.Unmarshal(data, &v); err != nil {
 			return err

--- a/numbers_test.go
+++ b/numbers_test.go
@@ -51,4 +51,10 @@ var _ = Describe("StringOrNumber", func() {
 		Expect(string(bin)).To(Equal(`"33"`))
 	})
 
+	It("should decode empty strings", func() {
+		var n StringOrNumber
+		Expect(json.Unmarshal([]byte(`""`), &n)).To(Succeed())
+		Expect(n).To(Equal(StringOrNumber("")))
+	})
+
 })


### PR DESCRIPTION
### Problem
json unmarshal error occurs when cid in bid response is empty string.

### WHY
Currently for StringOrNumber type, if field length = 2, it will be treated as number instead of string. When it comes to **""**, it throws the error.

### HOW
Change > 2 to >= 2, and add a test.

### JIRA
https://jira.hq.unity3d.com/browse/APIN-1932