### PR TITLE
Add IsOmEnabled flag to signal om creative from admob to sdk

### DIFF
--- a/bid.go
+++ b/bid.go
@@ -42,8 +42,9 @@ type Bid struct {
 	WRatio         int            `json:"wratio,omitempty"`         // Relative width of the creative when expressing size as a ratio.
 	HRatio         int            `json:"hratio,omitempty"`         // Relative height of the creative when expressing size as a ratio.
 	Exp            int            `json:"exp,omitempty"`            // Advisory as to the number of seconds the bidder is willing to wait between the auction and the actual impression.
-	ContentType    string         `json:"-"`                        // content of the bid
-	MediaType      string         `json:"-"`                        // media of the impression e.g. video/display
+	ContentType    string         `json:"-"`                        // Content of the bid
+	MediaType      string         `json:"-"`                        // Media of the impression e.g. video/display
+	IsOmEnabled    bool           `json:"-"`                        // Flag to send indicate to the Sdk whether or not to run om scripts
 	Ext            Extension      `json:"ext,omitempty"`
 }
 


### PR DESCRIPTION
We need a flag in the bid struct to set the value of `isOmCreative` to.  The IsOmEnabled will then be used to set the value of the types.Bid and the Media struct to send back to the SDK.