### PR TITLE
APIN-3028 Add network 5G and map it to the connectionType in the bid request

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -172,6 +172,7 @@ const (
 	ConnTypeCell2G   = 4
 	ConnTypeCell3G   = 5
 	ConnTypeCell4G   = 6
+	ConnTypeCell5G   = 7
 )
 
 // 5.19 No-Bid Reason Codes


### PR DESCRIPTION
Need to add new connectionType 5G for device.connectiontype.
Added new constant: ConnTypeCell5G = 7