### PR TITLE
Add Regulation Extension for PIPL

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -298,6 +298,7 @@ type Format struct {
 type RegExtension struct {
 	GDPR      int    `json:"gdpr,omitempty"`
 	LGPD      bool   `json:"lgpd,omitempty"`
+	PIPL      bool   `json:"pipl,omitempty"`
 	USPrivacy string `json:"us_privacy,omitempty"`
 }
 


### PR DESCRIPTION
Adds the `pipl` regulation extension to options

Relates to [MDP-721](https://jira.unity3d.com/browse/MDP-721).