### PR TITLE
Add gamerID to User Extension

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -305,6 +305,7 @@ type RegExtension struct {
 // UserExtension Extension object for User
 type UserExtension struct {
 	Consent string  `json:"consent,omitempty"`
+	GamerId string  `json:"gamerid,omitempty"`
 	SdkData SdkData `json:"sdkdata,omitempty"`
 }
 


### PR DESCRIPTION
Add gamerID to User Extension

Needed for Direct Demand Header Bidding integration and minimal/async token implementation, as key for stored token.

https://jira.unity3d.com/browse/DDHB-692