### PR TITLE
Add AppStartTime to UserExtension struct.

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -304,8 +304,9 @@ type RegExtension struct {
 
 // UserExtension Extension object for User
 type UserExtension struct {
-	Consent string  `json:"consent,omitempty"`
-	SdkData SdkData `json:"sdkdata,omitempty"`
+	Consent      string  `json:"consent,omitempty"`
+	SdkData      SdkData `json:"sdkdata,omitempty"`
+	AppStartTime int     `json:"appStartTime,omitempty"`
 }
 
 // SdkData object for UserExtension. Required for direct demand header bidding integration


### PR DESCRIPTION
### What

Add a new field AppStartTime to the UserExtension type in openrtb.

### Why

We have identified that there is a correlation between how long ago an app has been started and how much we overvaluate a bid request. We need to make this change so that we can propagate this information from the SDK to the HB Bidder through mz-exchange code base.
