### PR TITLE
banner vcm field to allow using banners as endcards

### DIFF
--- a/banner.go
+++ b/banner.go
@@ -22,5 +22,6 @@ type Banner struct {
 	TopFrame int       `json:"topframe,omitempty"` // Default: 0 ("1": Delivered in top frame, "0": Elsewhere)
 	ExpDir   []int     `json:"expdir,omitempty"`   // Specify properties for an expandable ad
 	Api      []int     `json:"api,omitempty"`      // List of supported API frameworks
+	VCM      int       `json:"vcm,omitempty"`      // Represents the relationship with video. 0 = concurrent, 1 = end-card
 	Ext      Extension `json:"ext,omitempty"`
 }


### PR DESCRIPTION
For work related to mraid endcards, we need to update banner.go to include VCM field which allows banners to be used as endcards for video impressions.