### PR TITLE
Add OAID device field to openrtb

### DIFF
--- a/device.go
+++ b/device.go
@@ -34,5 +34,6 @@ type Device struct {
 	PIDMD5     string    `json:"dpidmd5,omitempty"`    // MD5 hashed platform device ID
 	MacSHA1    string    `json:"macsha1,omitempty"`    // SHA1 hashed device ID; IMEI when available, else MEID or ESN
 	MacMD5     string    `json:"macmd5,omitempty"`     // MD5 hashed device ID; IMEI when available, else MEID or ESN
+	OAID       string    `json:"OAID,omitempty"`       // Open Advertising Tracking ID
 	Ext        Extension `json:"ext,omitempty"`
 }

--- a/device.go
+++ b/device.go
@@ -34,6 +34,6 @@ type Device struct {
 	PIDMD5     string    `json:"dpidmd5,omitempty"`    // MD5 hashed platform device ID
 	MacSHA1    string    `json:"macsha1,omitempty"`    // SHA1 hashed device ID; IMEI when available, else MEID or ESN
 	MacMD5     string    `json:"macmd5,omitempty"`     // MD5 hashed device ID; IMEI when available, else MEID or ESN
-	OAID       string    `json:"OAID,omitempty"`       // Open Advertising Tracking ID
+	OAID       string    `json:"oaid,omitempty"`       // Open Advertising Tracking ID
 	Ext        Extension `json:"ext,omitempty"`
 }

--- a/device_test.go
+++ b/device_test.go
@@ -39,6 +39,7 @@ var _ = Describe("Device", func() {
 			ConnType:   ConnTypeCell,
 			MCCMNC:     "722-341",
 			DeviceType: DeviceTypeMobile,
+			OAID:       "1fe9a970-efbb-29e0-0bdd-f5dbbf751ab5",
 		}))
 	})
 })


### PR DESCRIPTION
Add OAID device field to openrtb device struct. Technically this is not in the oRTB spec, but some of our DSPs require this field to live here. Our competitors also have the field live here instead of the device.ext object.

https://unity.slack.com/archives/CJC0H5SCW/p1655233367254089