### PR TITLE
Add user.ext.sessionId

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -307,6 +307,7 @@ type UserExtension struct {
 	Consent      string  `json:"consent,omitempty"`
 	SdkData      SdkData `json:"sdkdata,omitempty"`
 	AppStartTime int64   `json:"appStartTime,omitempty"`
+	SessionID    string  `json:"sessionId,omitempty"`
 }
 
 // SdkData object for UserExtension. Required for direct demand header bidding integration


### PR DESCRIPTION
## What
Add `user.ext.sessionId` property that represents session id

## Why
This id could be very useful for debugging of async valuation. In particular it could help us to investigate cases when we have inconsistent GameID/GamerID pair between pre-valuation and bid request - that could cause that we can't find pre-valuation during bid request

## How to verify change?
Send valid bid request  with session id to Bidder for example using e2e test suite https://github.com/Unity-Technologies/mz-header-bidding-e2e-test

## How it's tested?
Untested

## Does it change/break the contract with external/internal services?
No - it is an optional field
