### PR TITLE
[PPS-234] Add Rewarded Field to Impression

### DIFF
--- a/impression.go
+++ b/impression.go
@@ -35,6 +35,7 @@ type Impression struct {
 	ContentType       string         `json:"-"`                           // Used to attribute bid to a content - not sent in request
 	MediaType         string         `json:"-"`                           // media of the impression e.g. video/display
 	Ext               Extension      `json:"ext,omitempty"`
+	Rewarded          bool           `json:"rwdd,omitempty"` //Indicates whether the user receives a reward for viewing the ad
 }
 
 func (imp *Impression) assetCount() int {

--- a/impression_test.go
+++ b/impression_test.go
@@ -1,5 +1,10 @@
 package openrtb
 
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
 var _ = Describe("Impression", func() {
 	var subject *Impression
 

--- a/impression_test.go
+++ b/impression_test.go
@@ -1,10 +1,5 @@
 package openrtb
 
-import (
-	. "github.com/onsi/ginkgo"
-	. "github.com/onsi/gomega"
-)
-
 var _ = Describe("Impression", func() {
 	var subject *Impression
 
@@ -43,6 +38,7 @@ var _ = Describe("Impression", func() {
 					},
 				},
 			},
+			Rewarded: false,
 		}))
 	})
 


### PR DESCRIPTION
OpenRTB has a standard flag to showcase when an impression is rewarded in ORTB2.6.
The field is request.imp.rwdd. The value passed is an integer being 0 or 1.