### PR TITLE
Add load duration to user ext fields

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -304,10 +304,11 @@ type RegExtension struct {
 
 // UserExtension Extension object for User
 type UserExtension struct {
-	Consent      string  `json:"consent,omitempty"`
-	SdkData      SdkData `json:"sdkdata,omitempty"`
-	AppStartTime int64   `json:"appStartTime,omitempty"`
-	SessionID    string  `json:"sessionId,omitempty"`
+	Consent        string  `json:"consent,omitempty"`
+	SdkData        SdkData `json:"sdkdata,omitempty"`
+	AppStartTime   int64   `json:"appStartTime,omitempty"`
+	SessionID      string  `json:"sessionId,omitempty"`
+	AdLoadDuration int64   `json:"adLoadDuration,omitempty"`
 }
 
 // SdkData object for UserExtension. Required for direct demand header bidding integration


### PR DESCRIPTION
# WHAT

Add the `adLoadDuration` data to the user extension fields for the openrtb bidrequest.

# WHY

We have a problem where long creatives cannot be loaded in time for Android (in some cases). The hypothesis here is that the load duration could help us predict these cases where loading the creative takes too long and we could send a lower resolution creative when needed.