### PR TITLE
Handle incoming bool/int fields for lgpd

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -841,10 +841,10 @@ type ChannelEntity struct {
 
 // RegExtension Extension object for Regulations
 type RegExtension struct {
-	GDPR      int    `json:"gdpr,omitempty"`
-	LGPD      bool   `json:"lgpd,omitempty"`
-	PIPL      bool   `json:"pipl,omitempty"`
-	USPrivacy string `json:"us_privacy,omitempty"`
+	GDPR      int          `json:"gdpr,omitempty"`
+	LGPD      BoolOrNumber `json:"lgpd,omitempty"`
+	PIPL      BoolOrNumber `json:"pipl,omitempty"`
+	USPrivacy string       `json:"us_privacy,omitempty"`
 }
 
 // UserExtension Extension object for User


### PR DESCRIPTION
- Openrtb spec indicates using int instead of bool, however our current mediation partners send bool for RegExt.Lgpd
- Admob mediation follows the spec and will send an int, so we need a way to handle both, bool and ints.