### PR TITLE
[PPS-669] Always passing source.fd

### DIFF
--- a/audio_test.go
+++ b/audio_test.go
@@ -56,7 +56,7 @@ func TestAudio_Validate(t *testing.T) {
 		},
 		CompanionType: []int{VASTCompanionStatic, VASTCompanionHTML},
 	}
-	if exp, got := ErrInvalidAudioNoMimes, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidAudioNoMimes, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/bid_test.go
+++ b/bid_test.go
@@ -35,11 +35,11 @@ func TestBid(t *testing.T) {
 
 func TestBid_Validate(t *testing.T) {
 	subject := &Bid{}
-	if exp, got := ErrInvalidBidNoID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidBidNoID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &Bid{ID: "BIDID"}
-	if exp, got := ErrInvalidBidNoImpID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidBidNoImpID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/bidrequest_test.go
+++ b/bidrequest_test.go
@@ -74,15 +74,15 @@ func TestBidRequest_complex(t *testing.T) {
 
 func TestBidRequest_Validate(t *testing.T) {
 	subject := &BidRequest{}
-	if exp, got := ErrInvalidReqNoID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidReqNoID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &BidRequest{ID: "RID"}
-	if exp, got := ErrInvalidReqNoImps, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidReqNoImps, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &BidRequest{ID: "A", Imp: []Impression{{ID: "1"}}, Site: &Site{}, App: &App{}}
-	if exp, got := ErrInvalidReqMultiInv, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidReqMultiInv, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/bidresponse_test.go
+++ b/bidresponse_test.go
@@ -56,11 +56,11 @@ func TestBidResponse_complex(t *testing.T) {
 
 func TestBidResponse_Validate(t *testing.T) {
 	subject := &BidResponse{}
-	if exp, got := ErrInvalidRespNoID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidRespNoID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &BidResponse{ID: "RID"}
-	if exp, got := ErrInvalidRespNoSeatBids, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidRespNoSeatBids, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/impression_test.go
+++ b/impression_test.go
@@ -55,11 +55,11 @@ func TestImpression(t *testing.T) {
 
 func TestImpression_Validate(t *testing.T) {
 	subject := &Impression{}
-	if exp, got := ErrInvalidImpNoID, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidImpNoID, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &Impression{ID: "IMPID", Banner: &Banner{}, Video: &Video{}}
-	if exp, got := ErrInvalidImpMultiAssets, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidImpMultiAssets, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/seatbid_test.go
+++ b/seatbid_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestSeatBid_Validate(t *testing.T) {
 	subject := &SeatBid{}
-	if exp, got := ErrInvalidSeatBidBid, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidSeatBidBid, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }

--- a/source.go
+++ b/source.go
@@ -2,7 +2,7 @@ package openrtb
 
 // Source object describes the nature and behavior of the entity that is the source of the bid request upstream from the exchange.
 type Source struct {
-	FinalSaleDecision int       `json:"fd,omitempty"`     // Entity responsible for the final impression sale decision, where 0 = exchange, 1 = upstream source.
+	FinalSaleDecision int       `json:"fd"`               // Entity responsible for the final impression sale decision, where 0 = exchange, 1 = upstream source.
 	TransactionID     string    `json:"tid,omitempty"`    // Transaction ID that must be common across all participants in this bid request (e.g., potentially multiple exchanges).
 	PaymentChain      string    `json:"pchain,omitempty"` // Payment ID chain string containing embedded syntax described in the TAG Payment ID Protocol v1.0.
 	Ext               Extension `json:"ext,omitempty"`    // Placeholder for exchange-specific extensions to OpenRTB.

--- a/video_test.go
+++ b/video_test.go
@@ -52,11 +52,11 @@ func TestVideo(t *testing.T) {
 
 func TestVideo_Validate(t *testing.T) {
 	subject := &Video{}
-	if exp, got := ErrInvalidVideoNoMimes, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidVideoNoMimes, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &Video{Mimes: []string{"video/mp4"}}
-	if exp, got := ErrInvalidVideoNoLinearity, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidVideoNoLinearity, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 	subject = &Video{
@@ -65,7 +65,7 @@ func TestVideo_Validate(t *testing.T) {
 		Linearity:   VideoLinearityNonLinear,
 		Mimes:       []string{"video/mp4"},
 	}
-	if exp, got := ErrInvalidVideoNoProtocols, subject.Validate(); !errors.Is(exp, got) {
+	if exp, got := ErrInvalidVideoNoProtocols, subject.Validate(); !errors.Is(got, exp) {
 		t.Fatalf("expected %v, got %v", exp, got)
 	}
 }


### PR DESCRIPTION
we've noticed that Unity might not always pass source.fd in the bid request although it should always be passed, whether its 0 or 1.

https://jira.unity3d.com/browse/PPS-669

Also fixing lint failed:
![image](https://github.com/user-attachments/assets/8609291e-0344-4e91-8b7a-6eb4c5ea5258)
