### PR TITLE
make UserExtension SdkData optional

### DIFF
--- a/openrtb.go
+++ b/openrtb.go
@@ -849,10 +849,10 @@ type RegExtension struct {
 
 // UserExtension Extension object for User
 type UserExtension struct {
-	Consent      string  `json:"consent,omitempty"`
-	SdkData      SdkData `json:"sdkdata,omitempty"`
-	AppStartTime int64   `json:"appStartTime,omitempty"`
-	SessionID    string  `json:"sessionId,omitempty"`
+	Consent      string   `json:"consent,omitempty"`
+	SdkData      *SdkData `json:"sdkdata,omitempty"`
+	AppStartTime int64    `json:"appStartTime,omitempty"`
+	SessionID    string   `json:"sessionId,omitempty"`
 }
 
 // SdkData object for UserExtension. Required for direct demand header bidding integration


### PR DESCRIPTION
makes UserExtension.SdkData a pointer, so it can be omitted from the mashaled json